### PR TITLE
use more declaretive html in vanilla js example - fixes #4

### DIFF
--- a/vanilla-app/index.html
+++ b/vanilla-app/index.html
@@ -10,47 +10,41 @@
 
     <ul id="todos"></ul>
 
-    <form> 
+    <!-- `return false` is equal to `event.preventDefault()` -->
+    <form onsubmit="addTodo(this.elements.todo.value); this.reset(); return false">
         <input name="todo" type="text">
         <input type="submit" value="Add Todo">
     </form>
 
-
     <script>
+        'use strict'
 
         // Get DOM elements
         const form  = document.querySelector('form');
-        const input = document.querySelector("[name='todo']");
         const todoList = document.getElementById('todos');
 
-         // Side Effects / Lifecycle
-    
+        // Side Effects / Lifecycle
+
         const existingTodos = JSON.parse(localStorage.getItem('todos')) || [];
 
         const todoData = [];
-        
+
         existingTodos.forEach(todo => {
             addTodo(todo);
         });
 
+        function createListElement(text) {
+            const li = document.createElement('li');
+            li.textContent = text; // faster and safer than .innerHTML
+            return li;
+        }
 
         function addTodo(todoText) {
             todoData.push(todoText);
-            const li = document.createElement('li')
-            li.innerHTML = todoText;
-            todoList.appendChild(li);
+            todoList.appendChild(createListElement(todoText));
             localStorage.setItem('todos', JSON.stringify(todoData));
-            input.value = ''
         }
-
-        // Events
-        form.onsubmit = (event) => {
-            event.preventDefault();
-            addTodo(input.value);
-        }
-
-
     </script>
-    
+
 </body>
 </html>


### PR DESCRIPTION
An example of more declarative HTML. I don't think it ruins your point about bindings in frameworks. Obviously this example does not built the list, as virtual DOM would do for you and AFAIK there is no DOM way of doing that other than implementing it yourself in JS, which defeats the point of not using a framework.

I do not disagree with you at all and I really liked your video.

Anyway.. here is a better example of vanilla JS in my opinion.

Ref: https://github.com/fireship-io/10-javascript-frameworks/issues/4